### PR TITLE
Fix: important sampling and test dataset

### DIFF
--- a/sgm/data/data_co3d.py
+++ b/sgm/data/data_co3d.py
@@ -719,7 +719,7 @@ class CustomDataDictLoader(pl.LightningDataModule):
 
     def test_dataloader(self):
         return DataLoader(
-            self.train_dataset,
+            self.test_dataset,
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=self.num_workers,

--- a/sgm/modules/nerfsd_pytorch3d.py
+++ b/sgm/modules/nerfsd_pytorch3d.py
@@ -439,7 +439,7 @@ class NerfSDModule(nn.Module):
         dists_uniform = None
         weights_uniform = None
         resolution = (int(math.sqrt(xref.size(2))) if len(xref.shape) == 4 else xref.size(3))
-        input_patch_rays, ray_points, dists, ray_points_uniform, dists_uniform = (self.raymarcher(pose, resolution, weights=prev_weights, device=xref.device))
+        input_patch_rays, ray_points, dists, ray_points_uniform, dists_uniform = (self.raymarcher(pose, resolution, weights=prev_weights, imp_sample_next_step=imp_sample_next_step, device=xref.device))
         output, plane_features_attn = self.model(pose, xref, ray_points, input_patch_rays, mask_ref)
         weights = output[..., -1:]
         features = output[..., :-1]


### PR DESCRIPTION
previous version : 
- predicted density from the previous FeatureNeRF blocks is not used for importance sampling. 
- save train cameras as test cameras

update:
- predicted density from the previous FeatureNeRF is used for importance sampling. 
- save correct test camera in camera.bin 
🙏